### PR TITLE
Fix coupon API auth token key

### DIFF
--- a/src/services/couponApi.ts
+++ b/src/services/couponApi.ts
@@ -112,7 +112,7 @@ export interface UserProfileResponse {
 export const fetchUserProfile = async (): Promise<UserProfileResponse> => {
   console.log('👤 Fetching user profile...');
   
-  const authToken = localStorage.getItem('authToken');
+  const authToken = localStorage.getItem('auth_token');
   
   try {
     const response = await fetch(`${XANO_BASE_URL}/user_turbo`, {
@@ -143,7 +143,7 @@ export const fetchUserProfile = async (): Promise<UserProfileResponse> => {
 export const fetchCouponData = async (bookingId: number): Promise<CouponResponse> => {
   console.log('🎫 Fetching coupon data for booking ID:', bookingId);
   
-  const authToken = localStorage.getItem('authToken');
+  const authToken = localStorage.getItem('auth_token');
   
   try {
     const response = await fetch(`${XANO_BASE_URL}/get_bookings/user/detaiI`, {


### PR DESCRIPTION
## Summary
- Retrieve auth token with consistent `auth_token` key in coupon and user profile API helpers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 25 problems (11 errors, 14 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68b4184520f0832a8ff50fd6548d6c7a