### PR TITLE
feat: introduce bio top sheet for profiles

### DIFF
--- a/src/components/BioTopSheet.tsx
+++ b/src/components/BioTopSheet.tsx
@@ -1,0 +1,76 @@
+"use client";
+import React, { useEffect } from "react";
+import { X, Target, Rocket, Sparkles } from "lucide-react";
+
+type BioTopSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  name: string;
+  avatar: string;
+  statement: string;
+  bio?: string;
+  goals?: string[];
+  futureProjects?: string[];
+};
+
+export default function BioTopSheet({
+  open,
+  onClose,
+  name,
+  avatar,
+  statement,
+  bio = "Add your bio here…",
+  goals = ["Build festival collab squads", "Grow beauty look library", "Partner with 3 agencies"],
+  futureProjects = ["JFW BTS series", "Maison Savage launch collab", "Bali wellness x beauty format"]
+}: BioTopSheetProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-modal="true" aria-labelledby="bio-title" className="fixed inset-0 z-50">
+      <button aria-label="Close bio" onClick={onClose} className="absolute inset-0 bg-black/50" />
+      <div className="absolute inset-x-0 top-0 h-[75vh] md:h-[70vh] bg-white rounded-b-3xl shadow-2xl overflow-hidden">
+        <div className="relative h-48 md:h-56 bg-gradient-to-r from-pink-200 via-rose-200 to-fuchsia-200">
+          <img src={avatar} alt={name} loading="lazy" width={120} height={120}
+               className="absolute left-4 bottom-4 w-20 h-20 md:w-24 md:h-24 rounded-full border-4 border-white shadow" />
+          <button onClick={onClose} className="absolute right-4 top-4 p-2 rounded-full bg-white/80 hover:bg-white shadow" aria-label="Close">
+            <X className="w-5 h-5" />
+          </button>
+          <div className="absolute left-32 md:left-36 bottom-6 right-4">
+            <h2 id="bio-title" className="text-lg md:text-xl font-semibold">{name}</h2>
+            <p className="text-sm text-gray-700 line-clamp-2">{statement}</p>
+          </div>
+        </div>
+        <div className="h-[calc(75vh-12rem)] md:h-[calc(70vh-14rem)] overflow-y-auto px-4 md:px-6 py-4 space-y-6">
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+              <Sparkles className="w-4 h-4" /> Full Bio
+            </h3>
+            <p className="text-sm leading-6 text-gray-800">{bio}</p>
+          </section>
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+              <Target className="w-4 h-4" /> Goals
+            </h3>
+            <ul className="text-sm leading-6 text-gray-800 list-disc pl-5">
+              {goals.map((g, i) => <li key={i}>{g}</li>)}
+            </ul>
+          </section>
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+              <Rocket className="w-4 h-4" /> Future Projects
+            </h3>
+            <ul className="text-sm leading-6 text-gray-800 list-disc pl-5">
+              {futureProjects.map((p, i) => <li key={i}>{p}</li>)}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/BeautyProProfile.tsx
+++ b/src/pages/BeautyProProfile.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import BioTopSheet from "@/components/BioTopSheet";
+
+export default function BeautyProProfile() {
+  const [bioOpen, setBioOpen] = useState(false);
+
+  const profile = {
+    name: "Aria Chen",
+    avatar: "https://placehold.co/120x120?text=A",
+    statement: "Signature glam + editorial looks",
+    bio: "Beauty pro specializing in editorial and bridal looks. Based in Los Angeles.",
+  } as const;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-2xl mx-auto p-4 sm:p-6">
+        <div className="flex items-center gap-4">
+          <img
+            src={profile.avatar}
+            alt={profile.name}
+            loading="lazy"
+            width={80}
+            height={80}
+            className="w-20 h-20 rounded-full border-4 border-white shadow"
+          />
+          <div>
+            <h1 className="text-xl font-bold">{profile.name}</h1>
+            <p
+              className="text-sm text-gray-700 cursor-pointer"
+              onClick={() => setBioOpen(true)}
+            >
+              “{profile.statement}”
+            </p>
+          </div>
+        </div>
+      </div>
+      <BioTopSheet
+        open={bioOpen}
+        onClose={() => setBioOpen(false)}
+        name={profile.name}
+        avatar={profile.avatar}
+        statement={profile.statement || "Signature glam + editorial looks"}
+        bio={profile.bio}
+        goals={["Expand bridal clientele", "Host a masterclass series", "Collaborate with 3 global brands"]}
+        futureProjects={["NYFW backstage team", "Clean beauty tutorial series", "Pop-up glam studio"]}
+      />
+    </div>
+  );
+}
+

--- a/src/pages/UgcTiktokerProfilePinned.tsx
+++ b/src/pages/UgcTiktokerProfilePinned.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import BioTopSheet from "@/components/BioTopSheet";
 import { Share2, BadgeCheck, Pin, Instagram, Music2, Briefcase, Users } from "lucide-react";
 
 /**
@@ -9,6 +10,7 @@ import { Share2, BadgeCheck, Pin, Instagram, Music2, Briefcase, Users } from "lu
  */
 export default function UGCTiktokerProfilePinned() {
   const [openPinned, setOpenPinned] = useState<string | null>(null);
+  const [bioOpen, setBioOpen] = useState(false);
 
   const profile = {
     name: "Nina Rivera",
@@ -61,7 +63,7 @@ export default function UGCTiktokerProfilePinned() {
           </div>
         </div>
         <div className="px-4 pb-3">
-          <p className="text-sm font-medium text-gray-800">“{profile.claim}”</p>
+          <p className="text-sm font-medium text-gray-800 cursor-pointer" onClick={() => setBioOpen(true)}>“{profile.claim}”</p>
           <p className="text-xs text-gray-600 mt-1">{profile.bio}</p>
         </div>
         {/* Claris stats */}
@@ -166,6 +168,16 @@ export default function UGCTiktokerProfilePinned() {
         </div>
       )}
     </div>
+    <BioTopSheet
+      open={bioOpen}
+      onClose={() => setBioOpen(false)}
+      name={profile.name}
+      avatar={profile.avatar}
+      statement={profile.claim || "Helping brands shine with authentic TikToks ✨"}
+      bio={profile.bio}
+      goals={["Collaborate with 5 skincare brands", "Launch a weekly GRWM series", "Reach 50K followers"]}
+      futureProjects={["Behind-the-scenes collab vlog", "Maison Savage launch collab", "Bali wellness x beauty format"]}
+    />
   </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable BioTopSheet component for displaying detailed bios
- wire BioTopSheet into UGC TikToker and Beauty Pro profiles

## Testing
- `npm test` *(fails: npm: No such file or directory)*
- `npm run lint` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b93aa4884c832aae49bc24deb9856a