### PR TITLE
Link frontend user to Xano profile

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,33 @@
+const XANO_BASE_URL = 'https://xbut-eryu-hhsg.f2.xano.io/api:vGd6XDW3';
+
+export interface XanoUser {
+  id: number;
+  email: string;
+  name?: string;
+  // add other fields returned by Xano if needed
+}
+
+export const fetchCurrentUser = async (token: string): Promise<XanoUser | null> => {
+  try {
+    const response = await fetch(`${XANO_BASE_URL}/auth/me`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch user: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return {
+      id: data.id,
+      email: data.email,
+      name: data.name
+    };
+  } catch (error) {
+    console.error('Error fetching current user', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add service to fetch current Xano user via `/auth/me`
- retrieve and store Xano user profile on login and init

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3841a304832a87b335e9bf23d54f