### PR TITLE
Fix incorrect user endpoint

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -9,7 +9,7 @@ export interface XanoUser {
 
 export const fetchCurrentUser = async (token: string): Promise<XanoUser | null> => {
   try {
-    const response = await fetch(`${XANO_BASE_URL}/users/me`, {
+    const response = await fetch(`${XANO_BASE_URL}/user_turbo`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`


### PR DESCRIPTION
## Summary
- use Xano `user_turbo` endpoint to fetch current user

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb724df094832a861d1a48315a87e6