### PR TITLE
feat(xano): harden API client

### DIFF
--- a/src/services/xano.ts
+++ b/src/services/xano.ts
@@ -34,26 +34,45 @@ export interface PortfolioItem {
 }
 
 const API = import.meta.env.VITE_XANO_API as string;
-const TOKEN = import.meta.env.VITE_XANO_TOKEN as string;
+let TOKEN = import.meta.env.VITE_XANO_TOKEN as string;
 
-export interface XanoError extends Error {
+/** Allow overriding the token at runtime (e.g., from AuthContext) */
+export function setXanoToken(token: string) {
+  TOKEN = token;
+}
+
+export class XanoError extends Error {
   status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "XanoError";
+    this.status = status;
+  }
 }
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`${API}${path}`, {
     ...options,
     headers: {
-      ...(options.headers || {}),
+      Accept: "application/json",
+      "Content-Type": "application/json",
       Authorization: `Bearer ${TOKEN}`,
+      ...(options.headers || {}),
     },
   });
+  // Friendly handling of common statuses
+  if (res.status === 429) throw new XanoError("Rate limit hit. Try again shortly.", 429);
+  if (res.status === 401 || res.status === 403) throw new XanoError("Unauthorized. Check API token.", res.status);
   if (!res.ok) {
-    const err = new Error(res.statusText) as XanoError;
-    err.status = res.status;
-    throw err;
+    const text = await res.text().catch(() => "");
+    throw new XanoError(`Xano ${res.status}: ${text || res.statusText}`, res.status);
   }
-  return res.json() as Promise<T>;
+  const ctype = (res.headers.get("content-type") || "").toLowerCase();
+  if (!ctype.includes("application/json")) {
+    const text = await res.text().catch(() => "");
+    throw new XanoError(`Unexpected response format (expected JSON). Status ${res.status}.`, res.status);
+  }
+  return (await res.json()) as T;
 }
 
 export interface UserTurbo {
@@ -63,6 +82,10 @@ export interface UserTurbo {
   City?: string;
   countryCode?: string;
   bio?: string;
+  IG_account?: string | null;
+  Tiktok_account?: string | null;
+  InstagramApprovation?: boolean;
+  Tiktokapprovation?: boolean;
 }
 
 export function fetchUserTurbo() {
@@ -71,6 +94,8 @@ export function fetchUserTurbo() {
 
 // Returns a list of portfolio items for the authenticated user
 export function fetchPortfolio() {
-  return request<PortfolioItem[]>("/portfolio");
+  return request<PortfolioItem[] | PortfolioItem>("/portfolio").then((r) =>
+    Array.isArray(r) ? r : r ? [r] : []
+  );
 }
 


### PR DESCRIPTION
## Summary
- allow overriding Xano token and provide richer error handling
- enforce JSON headers and verify content types
- normalize portfolio fetch to always return an array

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af70cd80832aa9810bddffd484ec