### PR TITLE
Use localStorage auth token for Xano requests

### DIFF
--- a/src/services/xano.ts
+++ b/src/services/xano.ts
@@ -54,7 +54,6 @@ export interface XanoError {
 }
 
 const API = (import.meta.env.VITE_XANO_API || "https://xbut-eryu-hhsg.f2.xano.io/api:vGd6XDW3").replace(/\/$/, "");
-const TOKEN = import.meta.env.VITE_XANO_TOKEN || "";
 
 if (!API) {
   console.error("⚠️ Xano API URL missing");
@@ -74,14 +73,19 @@ export async function request<T>(path: string, options: RequestInit = {}) {
 
   // If caller didn't provide Authorization, try localStorage token first, then env token
   if (!headers.has("Authorization")) {
+    let token = "";
     try {
-      const lsToken = typeof window !== "undefined" ? localStorage.getItem("auth_token") || "" : "";
-      const envToken = import.meta.env.VITE_XANO_TOKEN || "";
-      const token = lsToken || envToken;
-      if (token) headers.set("Authorization", `Bearer ${token}`);
+      if (typeof window !== "undefined") {
+        token = localStorage.getItem("auth_token") || "";
+      }
     } catch {
-      const envToken = import.meta.env.VITE_XANO_TOKEN || "";
-      if (envToken) headers.set("Authorization", `Bearer ${envToken}`);
+      // ignore errors accessing localStorage
+    }
+    if (!token) {
+      token = import.meta.env.VITE_XANO_TOKEN || "";
+    }
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Pull JWT from `localStorage` before using `VITE_XANO_TOKEN`
- Set `Authorization` header only when a token is present

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3f3fba688832a85897f0c05a971a2