### PR TITLE
Integrate notched profile card shell

### DIFF
--- a/src/components/profile/CardNotchButton.tsx
+++ b/src/components/profile/CardNotchButton.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+/**
+ * CardNotchButton
+ * A composite card surface with a concave notch that docks a primary action button.
+ *
+ * Props:
+ * notch: "left" | "center" | "right" (default: "left")
+ * label: string (button label)
+ * onClick: () => void
+ * className: string (extra classes for the outer card)
+ * gradient: [from, to] tailwind color tokens (default: ["from-fuchsia-500","to-blue-600"])
+ * buttonSize: "sm" | "md" | "lg" (default: "md")
+ */
+export const CardNotchButton = ({
+  notch = "left",
+  label = "Hire",
+  onClick,
+  className = "",
+  gradient = ["from-fuchsia-500", "to-blue-600"],
+  buttonSize = "md",
+  children,
+  fill = "fill-black",
+}: React.PropsWithChildren<{
+  notch?: "left" | "center" | "right";
+  label?: string;
+  onClick?: () => void;
+  className?: string;
+  gradient?: [string, string];
+  buttonSize?: "sm" | "md" | "lg";
+  fill?: string;
+}>) => {
+  // Button sizing
+  const size =
+    buttonSize === "sm"
+      ? "px-4 py-1.5 text-sm rounded-2xl"
+      : buttonSize === "lg"
+      ? "px-6 py-3 text-base rounded-3xl"
+      : "px-5 py-2 text-sm rounded-3xl"; // md
+
+  // Horizontal position for the docked button
+  const btnX =
+    notch === "center"
+      ? "left-1/2 -translate-x-1/2"
+      : notch === "right"
+      ? "right-4"
+      : "left-4";
+
+  // SVG path generator for the notch shape
+  // Card viewBox is 1000x600 for precision; we map via preserveAspectRatio="none".
+  const pathD = (() => {
+    if (notch === "center") {
+      return "M0 0 H1000 V600 H530 C470 600 430 560 380 540 C330 520 300 560 250 580 H0 Z";
+    }
+    if (notch === "right") {
+      return "M0 0 H1000 V600 H860 C800 600 770 560 740 540 C710 520 680 560 620 580 H0 Z";
+    }
+    // left (default)
+    return "M0 0 H1000 V600 H240 C180 600 150 560 120 540 C90 520 60 560 0 580 Z";
+  })();
+
+  return (
+    <div className={"relative overflow-hidden rounded-2xl " + className}>
+      {/* SVG background with a soft, concave notch near the button */}
+      <svg
+        className="absolute inset-0 w-full h-full"
+        viewBox="0 0 1000 600"
+        preserveAspectRatio="none"
+      >
+        <path d={pathD} className={fill} />
+      </svg>
+
+      {/* Content area */}
+      <div className="relative p-6 pb-20">{children}</div>
+
+      {/* Docked primary action button */}
+      <div className={`absolute bottom-4 ${btnX}`}>
+        <button
+          onClick={onClick}
+          className={`bg-gradient-to-r ${gradient[0]} ${gradient[1]} font-semibold shadow-inner shadow-black/40 hover:brightness-110 active:brightness-95 transition ${size}`}
+        >
+          {label}
+        </button>
+        {/* subtle wave shadow under the button to accent the notch */}
+        <div
+          className="pointer-events-none absolute -bottom-2 left-2 right-2 h-3 rounded-full blur-[1px]"
+          style={{
+            background:
+              "radial-gradient(60px 10px at 30% 50%, rgba(46,46,56,.8), transparent 60%), radial-gradient(60px 10px at 70% 50%, rgba(46,46,56,.8), transparent 60%)",
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+

--- a/src/pages/UGCTiktokerProfilePinned.tsx
+++ b/src/pages/UGCTiktokerProfilePinned.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Header from '@/components/profile/Header';
 import UGCView from '@/components/profile/UGCView';
 import PROView from '@/components/profile/PROView';
+import { CardNotchButton } from '@/components/profile/CardNotchButton';
 import { Share2, Instagram, Music2 } from 'lucide-react';
 import { fetchUserProfile, type UserProfileResponse } from '@/services/couponApi';
 import { useNavigate } from 'react-router-dom';
@@ -98,9 +99,12 @@ export default function UGCTiktokerProfilePinned() {
       className={`min-h-screen transition-colors duration-700 ${isPro ? 'bg-black' : 'bg-white'}`}
     >
       <div className="max-w-2xl mx-auto p-4 sm:p-6">
-        <div
-          className={`rounded-2xl shadow-xl overflow-hidden transition-colors duration-700 ${
-            isPro ? 'bg-zinc-900' : 'bg-white'
+        <CardNotchButton
+          notch="left"
+          label="Hire"
+          fill={isPro ? 'fill-zinc-900' : 'fill-white'}
+          className={`w-full max-w-[720px] mx-auto shadow-xl transition-colors duration-700 ${
+            isPro ? 'bg-zinc-900 text-white' : 'bg-white text-black'
           }`}
         >
           <div
@@ -108,7 +112,7 @@ export default function UGCTiktokerProfilePinned() {
               isPro ? 'bg-gradient-to-r from-purple-900 to-pink-900' : 'bg-gradient-to-r from-fuchsia-200 to-pink-300'
             }`}
             style={{
-              backgroundImage: isPro 
+              backgroundImage: isPro
                 ? (profile.back?.url ? `url(${profile.back.url})` : undefined)
                 : (profile.UGC_cover?.url ? `url(${profile.UGC_cover.url})` : undefined),
               backgroundSize: 'cover',
@@ -168,37 +172,26 @@ export default function UGCTiktokerProfilePinned() {
             </div>
             <div className="flex items-center gap-3">
               <div className="block sm:hidden">
-              <div
-                tabIndex={0}
-                role="switch"
-                aria-checked={isPro}
-                onClick={toggle}
-                onKeyDown={onKeyDown}
-                className={`toggle-track ${isPro ? 'active' : ''} focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500`}
-              >
-                <div className="toggle-thumb" />
-                {!isPro && (
-                  <span className="absolute right-2 top-1/2 -translate-y-1/2 text-white text-[10px]">PRO</span>
-                )}
-                {isPro && (
-                  <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white text-[10px]">UGC</span>
-                )}
-               </div>
-             </div>
-           </div>
-         </div>
-        </div>
-
-        {isPro && (
-          <div className="mt-6 flex justify-start px-4">
-            <button className="relative px-6 py-2 text-sm font-medium rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg shadow-purple-500/30 overflow-hidden group transition-all duration-300 hover:shadow-xl hover:shadow-purple-500/40 hover:scale-105">
-              <span className="relative z-10">Hire</span>
-              <div className="absolute inset-0 bg-gradient-to-r from-purple-500 to-blue-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div className="absolute -inset-1 bg-gradient-to-r from-purple-600 to-blue-600 rounded-lg blur opacity-30 group-hover:opacity-50 transition-opacity duration-300 animate-pulse"></div>
-              <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-transparent via-white/10 to-transparent -skew-x-12 -translate-x-full group-hover:translate-x-full transition-transform duration-700 ease-out"></div>
-            </button>
+                <div
+                  tabIndex={0}
+                  role="switch"
+                  aria-checked={isPro}
+                  onClick={toggle}
+                  onKeyDown={onKeyDown}
+                  className={`toggle-track ${isPro ? 'active' : ''} focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500`}
+                >
+                  <div className="toggle-thumb" />
+                  {!isPro && (
+                    <span className="absolute right-2 top-1/2 -translate-y-1/2 text-white text-[10px]">PRO</span>
+                  )}
+                  {isPro && (
+                    <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white text-[10px]">UGC</span>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
-        )}
+        </CardNotchButton>
 
         {isPro ? <PROView /> : <UGCView />}
 


### PR DESCRIPTION
## Summary
- add reusable `CardNotchButton` shell with configurable notch and docked CTA
- wrap profile header in `CardNotchButton` for left-notch Hire button

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c76b42cb60832abe05cfff61275eda