### PR TITLE
Add inset tab card shell for portfolio cards

### DIFF
--- a/src/components/profile/CardShellWithInsetTab.tsx
+++ b/src/components/profile/CardShellWithInsetTab.tsx
@@ -1,0 +1,307 @@
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+export type InsetTabPosition = 'left' | 'center' | 'right';
+
+export interface InsetTabPathOptions {
+  width: number;
+  height: number;
+  tabWidth: number;
+  tabDepth: number;
+  tabRoundness: number;
+  tabPosition: InsetTabPosition;
+  cornerRadius?: number;
+}
+
+export interface InsetTabPathResult {
+  path: string;
+  tabStartX: number;
+  tabEndX: number;
+  apexX: number;
+  width: number;
+  height: number;
+  cornerRadius: number;
+}
+
+export interface CardShellWithInsetTabProps extends React.HTMLAttributes<HTMLDivElement> {
+  tabPosition?: InsetTabPosition;
+  tabWidth?: number;
+  tabDepth?: number;
+  tabRoundness?: number;
+  tabSlot?: React.ReactNode;
+  children: React.ReactNode;
+  innerClassName?: string;
+  backgroundClassName?: string;
+}
+
+const DEFAULT_SIZE = { width: 360, height: 320 };
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export interface InsetTabPreset {
+  tabPosition: InsetTabPosition;
+  tabWidth: number;
+  tabDepth: number;
+  tabRoundness: number;
+}
+
+export const insetTabPresets: Record<InsetTabPosition, InsetTabPreset> = {
+  left: {
+    tabPosition: 'left',
+    tabWidth: 180,
+    tabDepth: 44,
+    tabRoundness: 0.7,
+  },
+  center: {
+    tabPosition: 'center',
+    tabWidth: 220,
+    tabDepth: 48,
+    tabRoundness: 0.8,
+  },
+  right: {
+    tabPosition: 'right',
+    tabWidth: 180,
+    tabDepth: 44,
+    tabRoundness: 0.7,
+  },
+};
+
+export function generateInsetTabPath(options: InsetTabPathOptions): InsetTabPathResult {
+  const {
+    width,
+    height,
+    tabWidth,
+    tabDepth,
+    tabRoundness,
+    tabPosition,
+    cornerRadius = 24,
+  } = options;
+
+  const w = Math.max(width, DEFAULT_SIZE.width);
+  const h = Math.max(height, DEFAULT_SIZE.height);
+  const r = clamp(cornerRadius, 12, Math.min(w, h) / 4);
+  const margin = r + 12;
+
+  const usableWidth = Math.max(w - margin * 2, 80);
+  const clampedTabWidth = clamp(tabWidth, 80, usableWidth);
+
+  let tabStart: number;
+  switch (tabPosition) {
+    case 'left':
+      tabStart = margin;
+      break;
+    case 'right':
+      tabStart = w - margin - clampedTabWidth;
+      break;
+    default:
+      tabStart = (w - clampedTabWidth) / 2;
+      break;
+  }
+  tabStart = clamp(tabStart, margin, w - margin - clampedTabWidth);
+  const tabEnd = tabStart + clampedTabWidth;
+
+  const maxDepth = h - r - 16;
+  const depth = clamp(tabDepth, 20, maxDepth);
+  const roundness = clamp(tabRoundness, 0, 1);
+
+  const apexX = tabStart + clampedTabWidth / 2;
+  const apexY = h - depth;
+  const curveWidth = Math.max(clampedTabWidth / 2 - 12, clampedTabWidth * (0.2 + roundness * 0.15));
+  const controlOffset = Math.min(curveWidth, clampedTabWidth / 2 - 8);
+  const depthEase = depth * (0.55 + roundness * 0.25);
+
+  const commands = [
+    `M ${r},0`,
+    `H ${w - r}`,
+    `C ${w - r * 0.4},0 ${w},${r * 0.4} ${w},${r}`,
+    `V ${h - r}`,
+    `C ${w},${h - r * 0.4} ${w - r * 0.4},${h} ${w - r},${h}`,
+    `H ${tabEnd}`,
+    `C ${tabEnd - controlOffset},${h} ${apexX + controlOffset * 0.3},${apexY + depthEase} ${apexX},${apexY}`,
+    `C ${apexX - controlOffset * 0.3},${apexY + depthEase} ${tabStart + controlOffset},${h} ${tabStart},${h}`,
+    `H ${r}`,
+    `C ${r * 0.4},${h} 0,${h - r * 0.4} 0,${h - r}`,
+    `V ${r}`,
+    `C 0,${r * 0.4} ${r * 0.4},0 ${r},0`,
+    'Z',
+  ];
+
+  return {
+    path: commands.join(' '),
+    tabStartX: tabStart,
+    tabEndX: tabEnd,
+    apexX,
+    width: w,
+    height: h,
+    cornerRadius: r,
+  };
+}
+
+function formatPathForClip(path: string) {
+  return `path('${path}')`;
+}
+
+export const CardShellWithInsetTab = React.forwardRef<HTMLDivElement, CardShellWithInsetTabProps>(
+  (
+    {
+      tabPosition = insetTabPresets.left.tabPosition,
+      tabWidth = insetTabPresets.left.tabWidth,
+      tabDepth = insetTabPresets.left.tabDepth,
+      tabRoundness = insetTabPresets.left.tabRoundness,
+      tabSlot,
+      children,
+      className,
+      innerClassName,
+      backgroundClassName,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const localRef = useRef<HTMLDivElement | null>(null);
+    const [size, setSize] = useState(DEFAULT_SIZE);
+
+    const setRefs = useCallback(
+      (node: HTMLDivElement | null) => {
+        localRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+      },
+      [ref],
+    );
+
+    useLayoutEffect(() => {
+      const element = localRef.current;
+      if (!element || typeof ResizeObserver === 'undefined') {
+        return;
+      }
+
+      const updateSize = () => {
+        const rect = element.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+        setSize((prev) => {
+          if (Math.abs(prev.width - rect.width) < 0.5 && Math.abs(prev.height - rect.height) < 0.5) {
+            return prev;
+          }
+          return { width: rect.width, height: rect.height };
+        });
+      };
+
+      updateSize();
+
+      const observer = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect;
+          if (!width || !height) continue;
+          setSize((prev) => {
+            if (Math.abs(prev.width - width) < 0.5 && Math.abs(prev.height - height) < 0.5) {
+              return prev;
+            }
+            return { width, height };
+          });
+        }
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    }, []);
+
+    const metrics = useMemo(
+      () =>
+        generateInsetTabPath({
+          width: size.width,
+          height: size.height,
+          tabWidth,
+          tabDepth,
+          tabRoundness,
+          tabPosition,
+        }),
+      [size.width, size.height, tabWidth, tabDepth, tabRoundness, tabPosition],
+    );
+
+    const clipPath = formatPathForClip(metrics.path);
+    const tabSpan = metrics.tabEndX - metrics.tabStartX;
+    const slotLeft =
+      tabPosition === 'left'
+        ? metrics.tabStartX + 16
+        : tabPosition === 'right'
+        ? metrics.tabEndX - 16
+        : metrics.apexX;
+    const slotTransform =
+      tabPosition === 'left'
+        ? 'translateX(0)'
+        : tabPosition === 'right'
+        ? 'translateX(-100%)'
+        : 'translateX(-50%)';
+    const slotBottom = Math.max(10, tabDepth - 18);
+    const slotWidth = Math.max(140, tabSpan * 0.6);
+
+    return (
+      <div
+        ref={setRefs}
+        className={cn('relative', className)}
+        style={{ ...style, '--inset-tab-path': clipPath } as React.CSSProperties}
+        {...rest}
+      >
+        <div
+          className={cn('relative overflow-hidden', innerClassName)}
+          style={{
+            clipPath,
+            WebkitClipPath: clipPath,
+          }}
+        >
+          <div
+            className={cn(
+              'absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-900 to-zinc-900',
+              backgroundClassName,
+            )}
+          />
+          <svg
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 h-full w-full"
+            viewBox={`0 0 ${metrics.width} ${metrics.height}`}
+            preserveAspectRatio="none"
+          >
+            <path
+              d={metrics.path}
+              fill="none"
+              stroke="rgba(255,255,255,0.08)"
+              strokeWidth={1.25}
+            />
+          </svg>
+          <div className="relative flex h-full w-full flex-col">{children}</div>
+        </div>
+        {tabSlot ? (
+          <div
+            className="pointer-events-none absolute"
+            style={{
+              left: slotLeft,
+              bottom: slotBottom,
+              transform: `${slotTransform}`,
+            }}
+          >
+            <div className="pointer-events-auto relative inline-flex justify-center">
+              <div
+                aria-hidden="true"
+                className="absolute left-1/2 top-full h-10 w-full -translate-x-1/2 -translate-y-3 opacity-70"
+                style={{
+                  minWidth: slotWidth,
+                  background:
+                    'radial-gradient(circle at center, rgba(99, 102, 241, 0.28), rgba(79, 70, 229, 0.12) 55%, transparent 75%)',
+                }}
+              />
+              {tabSlot}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+CardShellWithInsetTab.displayName = 'CardShellWithInsetTab';
+

--- a/src/components/profile/PROView.tsx
+++ b/src/components/profile/PROView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { fetchPortfolio, type PortfolioItem, XanoError } from '@/services/xano';
 import { Pin, Briefcase } from 'lucide-react';
+import { CardShellWithInsetTab, insetTabPresets } from './CardShellWithInsetTab';
 
 export default function PROView() {
   const navigate = useNavigate();
@@ -43,12 +44,28 @@ export default function PROView() {
         {pfLoading && (
           <div className="grid gap-4">
             {[1, 2].map((i) => (
-              <div
+              <CardShellWithInsetTab
                 key={i}
-                className="relative rounded-lg overflow-hidden shadow bg-white"
+                className="rounded-2xl"
+                tabPosition={insetTabPresets.left.tabPosition}
+                tabWidth={insetTabPresets.left.tabWidth}
+                tabDepth={insetTabPresets.left.tabDepth}
+                tabRoundness={insetTabPresets.left.tabRoundness}
+                tabSlot={
+                  <div className="h-9 w-28 rounded-full bg-slate-500/60" aria-hidden="true" />
+                }
+                innerClassName="h-full animate-pulse"
+                backgroundClassName="bg-slate-800"
               >
-                <div className="w-full h-40 sm:h-56 bg-gray-200 animate-pulse" />
-              </div>
+                <div className="flex h-full flex-col">
+                  <div className="h-40 w-full bg-slate-700/60 sm:h-56" />
+                  <div className="flex-1 px-5 pb-6 pt-4">
+                    <div className="h-3 w-1/2 rounded-full bg-slate-600/70" />
+                    <div className="mt-3 h-3 w-3/4 rounded-full bg-slate-600/60" />
+                    <div className="mt-3 h-3 w-2/3 rounded-full bg-slate-600/50" />
+                  </div>
+                </div>
+              </CardShellWithInsetTab>
             ))}
           </div>
         )}
@@ -72,46 +89,94 @@ export default function PROView() {
               const brandName =
                 (p.Brand && p.Brand[0]?.BrandName) || "Untitled Project";
               const title = `${brandName}${p.Deliverables ? " — " + p.Deliverables : ""}`;
+              const deliverables = p.Deliverables?.trim();
+              const about = p.About?.trim();
 
               return (
-                <div
+                <CardShellWithInsetTab
                   key={p.id}
                   onClick={() => navigate(`/case/${p.id}`)}
-                  className="relative rounded-lg overflow-hidden shadow bg-white cursor-pointer hover:shadow-lg transition-shadow"
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      navigate(`/case/${p.id}`);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`View project ${p.Name || brandName}`}
+                  className="group relative cursor-pointer rounded-2xl transition-shadow duration-200 hover:shadow-[0_24px_60px_-35px_rgba(99,102,241,0.75)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70"
+                  innerClassName="h-full"
+                  tabPosition={insetTabPresets.left.tabPosition}
+                  tabWidth={insetTabPresets.left.tabWidth}
+                  tabDepth={insetTabPresets.left.tabDepth}
+                  tabRoundness={insetTabPresets.left.tabRoundness}
+                  tabSlot={
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
+                      className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-fuchsia-500/30 transition duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    >
+                      Hire
+                    </button>
+                  }
                 >
-                  {/* Cover full-bleed */}
-                  <div className="relative">
-                    <img
-                      src={cover}
-                      alt={title}
-                      className="w-full h-40 sm:h-56 object-cover"
-                      loading="lazy"
-                    />
+                  <div className="flex h-full flex-col">
+                    <div className="relative">
+                      <img
+                        src={cover}
+                        alt={title}
+                        className="h-40 w-full object-cover sm:h-56"
+                        loading="lazy"
+                      />
 
-                    {/* Overlay pill stretta e centrata */}
-                    <div className="absolute bottom-3 left-3 px-3 py-1.5 bg-black/40 backdrop-blur-sm rounded-full flex items-center gap-2 max-w-[60%]">
-                      {/* Brand tondo: usa il primo logo disponibile se c'è */}
-                      {brands.length > 0 ? (
-                        <img
-                          src={brands[0] as string}
-                          alt={`${brandName} logo`}
-                          className="w-9 h-9 rounded-full border border-white/60 object-cover flex-shrink-0"
-                        />
-                      ) : (
-                        <div className="w-9 h-9 rounded-full bg-white/80 border border-white/60 flex items-center justify-center text-[10px] text-gray-600 flex-shrink-0">
-                          LOGO
-                        </div>
-                      )}
-
-                      {/* Titolo compatto, tronco se lungo */}
-                      <div className="min-w-0">
-                        <div className="text-white text-sm font-semibold truncate">
-                          {p.Name || "Untitled Project"}
+                      <div className="absolute bottom-4 left-4 flex items-center gap-3 rounded-full bg-black/45 px-3 py-1.5 backdrop-blur-sm">
+                        {brands.length > 0 ? (
+                          <img
+                            src={brands[0] as string}
+                            alt={`${brandName} logo`}
+                            className="h-9 w-9 flex-shrink-0 rounded-full border border-white/60 object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-white/60 bg-white/80 text-[10px] font-semibold tracking-widest text-slate-600">
+                            LOGO
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-white drop-shadow-sm">
+                            {p.Name || 'Untitled Project'}
+                          </p>
+                          <p className="text-xs text-slate-200/80">
+                            {brandName}
+                          </p>
                         </div>
                       </div>
                     </div>
+                    <div className="flex flex-1 flex-col justify-end px-5 pb-6 pt-4 text-sm text-slate-200/80">
+                      {deliverables ? (
+                        <>
+                          <span className="text-xs uppercase tracking-[0.24em] text-indigo-200/70">
+                            Deliverables
+                          </span>
+                          <p className="mt-2 font-medium text-slate-100">
+                            {deliverables}
+                          </p>
+                        </>
+                      ) : (
+                        <p className="font-medium text-slate-100">
+                          View the full case study
+                        </p>
+                      )}
+                      {about ? (
+                        <p className="mt-3 line-clamp-2 text-sm text-slate-300/80">
+                          {about}
+                        </p>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
+                </CardShellWithInsetTab>
               );
             })}
             {(!Array.isArray(portfolio) || !portfolio.length) && (


### PR DESCRIPTION
## Summary
- add a reusable `CardShellWithInsetTab` component with SVG-based inset tab path generation and presets
- wrap PROView portfolio cards in the new shell, reposition overlays, and dock a gradient Hire button inside the notch
- refresh the loading skeleton to preview the new geometry while data is fetched

## Testing
- npm run lint *(fails: missing `@eslint/js` because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c882f90508832abe6b8cacd6c20040