### PR TITLE
Enhance portfolio upload UI

### DIFF
--- a/src/components/WorkBodyUploader.tsx
+++ b/src/components/WorkBodyUploader.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+
+export type WBFile = File & { __url?: string };
+
+type Props = {
+  files: WBFile[];
+  onChange: (files: WBFile[]) => void;
+  max?: number; // default 12
+};
+
+export default function WorkBodyUploader({ files, onChange, max = 12 }: Props) {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [dragIdx, setDragIdx] = React.useState<number | null>(null);
+  const [isOver, setIsOver] = React.useState(false);
+
+  const withPreview = (f: File): WBFile => Object.assign(f, { __url: URL.createObjectURL(f) });
+  const dedupMerge = (current: WBFile[], added: File[]) => {
+    const key = (f: File) => `${f.name}_${f.size}_${(f as any).lastModified ?? ""}`;
+    const map = new Map(current.map(f => [key(f), f]));
+    for (const f of added) {
+      const k = key(f);
+      if (!map.has(k)) map.set(k, withPreview(f));
+    }
+    return Array.from(map.values()).slice(0, max);
+  };
+
+  const handleInput = (filesList: FileList | null) => {
+    if (!filesList) return;
+    onChange(dedupMerge(files, Array.from(filesList)));
+  };
+
+  const handleClickAdd = () => inputRef.current?.click();
+
+  // Reorder
+  const onDragStart = (i: number) => (e: React.DragEvent) => {
+    setDragIdx(i);
+    e.dataTransfer.effectAllowed = "move";
+  };
+  const onDragOver = (i: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+  const onDrop = (i: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragIdx === null || dragIdx === i) return;
+    const next = [...files];
+    const [moved] = next.splice(dragIdx, 1);
+    next.splice(i, 0, moved);
+    onChange(next);
+    setDragIdx(null);
+  };
+
+  // Drop add
+  const onContainerDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsOver(false);
+    const fl = e.dataTransfer.files;
+    if (fl && fl.length) onChange(dedupMerge(files, Array.from(fl)));
+  };
+
+  // Paste support
+  React.useEffect(() => {
+    const onPaste = (e: ClipboardEvent) => {
+      const items = Array.from(e.clipboardData?.files ?? []);
+      if (items.length) onChange(dedupMerge(files, items));
+    };
+    window.addEventListener("paste", onPaste as any);
+    return () => window.removeEventListener("paste", onPaste as any);
+  }, [files]);
+
+  return (
+    <div
+      className={`rounded-xl border-2 border-dashed p-2 transition-colors ${
+        isOver ? "border-pink-500 bg-pink-500/5" : "border-neutral-400 dark:border-neutral-700"
+      }`}
+      onDragOver={(e) => { e.preventDefault(); setIsOver(true); }}
+      onDragLeave={() => setIsOver(false)}
+      onDrop={onContainerDrop}
+    >
+      <div className="grid grid-cols-3 gap-2">
+        {files.map((f, i) => (
+          <div
+            key={i}
+            className={`group relative aspect-square overflow-hidden rounded-lg border ${
+              dragIdx === i ? "ring-2 ring-pink-500" : "border-neutral-200 dark:border-neutral-700"
+            }`}
+            draggable
+            onDragStart={onDragStart(i)}
+            onDragOver={onDragOver(i)}
+            onDrop={onDrop(i)}
+            title={f.name}
+          >
+            <img src={f.__url as string} alt={f.name} className="h-full w-full object-cover" />
+            <div className="absolute inset-x-1 top-1 flex justify-between opacity-0 group-hover:opacity-100 transition">
+              <button
+                type="button"
+                className="rounded-md bg-black/60 px-2 py-1 text-[11px] text-white"
+                onClick={() => { const next = [...files]; next.splice(i, 1); onChange(next); }}
+              >
+                Remove
+              </button>
+              <label className="rounded-md bg-black/60 px-2 py-1 text-[11px] text-white cursor-pointer">
+                Replace
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    const fl = e.target.files?.[0];
+                    if (!fl) return;
+                    const next = [...files]; next[i] = withPreview(fl); onChange(next);
+                  }}
+                />
+              </label>
+            </div>
+            <div className="pointer-events-none absolute bottom-1 right-1 rounded bg-black/60 px-1.5 py-0.5 text-[10px] text-white">
+              Drag to reorder
+            </div>
+          </div>
+        ))}
+
+        {/* Add tile */}
+        {files.length < max && (
+          <button
+            type="button"
+            onClick={handleClickAdd}
+            className="group relative aspect-square rounded-lg border-2 border-dashed border-neutral-400 dark:border-neutral-700 hover:border-pink-500 transition-colors"
+          >
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-500 text-white group-hover:bg-pink-600 transition">
+                <span className="text-2xl font-bold leading-none">+</span>
+              </div>
+              <span className="mt-2 text-xs opacity-80">Add images</span>
+            </div>
+          </button>
+        )}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={(e) => handleInput(e.target.files)}
+      />
+
+      <div className="mt-2 flex items-center justify-between text-[11px] opacity-70">
+        <span>{files.length}/{max} selected • Drag to reorder • Paste or Drop files</span>
+        <button
+          type="button"
+          onClick={handleClickAdd}
+          className="rounded-full bg-black text-white dark:bg-white dark:text-black px-3 py-1 text-[11px]"
+        >
+          + Add more
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PortfolioNewPage.tsx
+++ b/src/pages/PortfolioNewPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { request, uploadFileToXano, uploadFilesToXano } from "@/services/xano";
 import { useNavigate } from "react-router-dom";
+import WorkBodyUploader, { WBFile } from "@/components/WorkBodyUploader";
 
 type BrandLite = { id: number; BrandName: string; LogoBrand?: { url?: string } };
 type UserLite  = { id: number; handle?: string; name?: string; avatar?: { url?: string } };
@@ -54,7 +55,7 @@ const PortfolioNewPage: React.FC = () => {
   // --- State per Upload ---
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [heroFile, setHeroFile]   = useState<File | null>(null);
-  const [workFiles, setWorkFiles] = useState<File[]>([]);
+  const [workFiles, setWorkFiles] = useState<WBFile[]>([]);
 
   // --- Brand search (multi) ---
   const [brandQuery, setBrandQuery] = useState("");
@@ -97,7 +98,6 @@ const PortfolioNewPage: React.FC = () => {
   // --- Helpers ---
   const previewCover = useMemo(() => (coverFile ? URL.createObjectURL(coverFile) : null), [coverFile]);
   const previewHero  = useMemo(() => (heroFile ? URL.createObjectURL(heroFile) : null), [heroFile]);
-  const previewWorks = useMemo(() => workFiles.map(f => ({ name: f.name, url: URL.createObjectURL(f) })), [workFiles]);
 
   function parseKPI(txt?: string) {
     const rows = (txt || "").split("\n").map(s => s.trim()).filter(Boolean);
@@ -278,46 +278,69 @@ const PortfolioNewPage: React.FC = () => {
           </div>
 
           {/* --- Uploaders --- */}
+          {/* Cover upload */}
           <div>
             <label className={label}>Cover (immagine singola)</label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={(e) => setCoverFile(e.target.files?.[0] || null)}
-              className={input}
-            />
-            {previewCover && <img src={previewCover} alt="cover" className="mt-2 w-full rounded-xl border" />}
+            <div className="mt-2">
+              <label
+                htmlFor="cover-upload"
+                className="group relative flex h-36 w-full cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed border-neutral-400 dark:border-neutral-700 hover:border-pink-500 transition-colors"
+              >
+                {previewCover ? (
+                  <img src={previewCover} alt="cover" className="absolute inset-0 h-full w-full object-cover rounded-xl" />
+                ) : (
+                  <div className="flex flex-col items-center justify-center text-center">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-500 text-white group-hover:bg-pink-600 transition-colors">
+                      <span className="text-2xl font-bold leading-none">+</span>
+                    </div>
+                    <span className="mt-2 text-xs opacity-80">Aggiungi Cover</span>
+                  </div>
+                )}
+              </label>
+              <input
+                id="cover-upload"
+                type="file"
+                accept="image/*"
+                onChange={(e) => setCoverFile(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+            </div>
           </div>
 
+          {/* Hero upload */}
           <div>
             <label className={label}>Hero (immagine singola)</label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={(e) => setHeroFile(e.target.files?.[0] || null)}
-              className={input}
-            />
-            {previewHero && <img src={previewHero} alt="hero" className="mt-2 w-full rounded-xl border" />}
+            <div className="mt-2">
+              <label
+                htmlFor="hero-upload"
+                className="group relative flex h-36 w-full cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed border-neutral-400 dark:border-neutral-700 hover:border-pink-500 transition-colors"
+              >
+                {previewHero ? (
+                  <img src={previewHero} alt="hero" className="absolute inset-0 h-full w-full object-cover rounded-xl" />
+                ) : (
+                  <div className="flex flex-col items-center justify-center text-center">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-500 text-white group-hover:bg-pink-600 transition-colors">
+                      <span className="text-2xl font-bold leading-none">+</span>
+                    </div>
+                    <span className="mt-2 text-xs opacity-80">Aggiungi Hero</span>
+                  </div>
+                )}
+              </label>
+              <input
+                id="hero-upload"
+                type="file"
+                accept="image/*"
+                onChange={(e) => setHeroFile(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+            </div>
           </div>
 
           <div>
             <label className={label}>Work Body (più immagini)</label>
-            <input
-              type="file"
-              accept="image/*"
-              multiple
-              onChange={(e) => setWorkFiles(Array.from(e.target.files || []))}
-              className={input}
-            />
-            {!!previewWorks.length && (
-              <div className="mt-2 grid grid-cols-3 gap-2">
-                {previewWorks.map((p, i) => (
-                  <div key={i} className="aspect-square overflow-hidden rounded-lg border">
-                    <img src={p.url} className="h-full w-full object-cover" alt={p.name} />
-                  </div>
-                ))}
-              </div>
-            )}
+            <div className="mt-2">
+              <WorkBodyUploader files={workFiles} onChange={setWorkFiles} max={12} />
+            </div>
           </div>
 
           {/* KPI facoltativa */}


### PR DESCRIPTION
## Summary
- add a reusable WorkBodyUploader component with drag/drop, deduplication, and inline management controls
- restyle the cover and hero pickers on PortfolioNewPage with modern plus-tile presentation
- replace the legacy work body input with the new uploader for previews, reordering, and smarter additions

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d696699c832ab953dfcad5e76af3