### PR TITLE
feat: post portfolio formdata directly

### DIFF
--- a/src/services/xano.ts
+++ b/src/services/xano.ts
@@ -57,29 +57,18 @@ export interface XanoError {
 }
 
 const API = (import.meta.env.VITE_XANO_API || "https://xbut-eryu-hhsg.f2.xano.io/api:vGd6XDW3").replace(/\/$/, "");
-const UPLOAD_PATH = import.meta.env.VITE_XANO_UPLOAD_PATH || "/upload";
-
-function authHeadersForUpload(): Headers {
-  const headers = new Headers();
-
-  if (!headers.has("Authorization")) {
-    let token = "";
-    try {
-      if (typeof window !== "undefined") {
-        token = localStorage.getItem("auth_token") || "";
-      }
-    } catch {
-      // ignore errors accessing localStorage
+export function getAuthToken(): string {
+  try {
+    if (typeof window !== "undefined") {
+      return (
+        localStorage.getItem("user_turbo_id_token") ||
+        localStorage.getItem("user_turbo_token") ||
+        localStorage.getItem("auth_token") ||
+        ""
+      );
     }
-    if (!token) {
-      token = import.meta.env.VITE_XANO_TOKEN || "";
-    }
-    if (token) {
-      headers.set("Authorization", `Bearer ${token}`);
-    }
-  }
-
-  return headers;
+  } catch {}
+  return "";
 }
 
 if (!API) {
@@ -100,14 +89,7 @@ export async function request<T>(path: string, options: RequestInit = {}) {
 
   // If caller didn't provide Authorization, try localStorage token first, then env token
   if (!headers.has("Authorization")) {
-    let token = "";
-    try {
-      if (typeof window !== "undefined") {
-        token = localStorage.getItem("auth_token") || "";
-      }
-    } catch {
-      // ignore errors accessing localStorage
-    }
+    let token = getAuthToken();
     if (!token) {
       token = import.meta.env.VITE_XANO_TOKEN || "";
     }
@@ -148,26 +130,3 @@ export async function fetchPortfolio() {
   return Array.isArray(data) ? data : data ? [data as PortfolioItem] : [];
 }
 
-export async function uploadFileToXano(file: File) {
-  const url = `${API}${UPLOAD_PATH}`;
-  const form = new FormData();
-  form.append("file", file);
-
-  const headers = authHeadersForUpload();
-
-  const res = await fetch(url, { method: "POST", body: form, headers });
-  if (!res.ok) {
-    const msg = await res.text().catch(() => res.statusText);
-    throw Object.assign(new Error(`Upload error ${res.status}: ${msg}`), { status: res.status });
-  }
-  return res.json() as Promise<{ url: string } & Record<string, any>>;
-}
-
-export async function uploadFilesToXano(files: File[]) {
-  const results = [];
-  for (const f of files) {
-    const r = await uploadFileToXano(f);
-    results.push(r);
-  }
-  return results;
-}


### PR DESCRIPTION
## Summary
- add a reusable `getAuthToken` helper that restores the multi-key lookup used for Xano auth
- drop the legacy `/upload` helpers and update the new portfolio page to post a multipart form directly to `/portfolio`
- keep the existing UI flows while wiring brand, team, and KPI data into the new request format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4098aeca8832a82f3e40fd70aa3c9