### PR TITLE
feat: add reusable brand search select

### DIFF
--- a/src/components/BrandSearchSelect.tsx
+++ b/src/components/BrandSearchSelect.tsx
@@ -1,0 +1,241 @@
+import React from "react";
+import { searchBrands } from "@/services/brands";
+import type { BrandLite } from "@/services/brands";
+
+type Props = {
+  value: BrandLite[];
+  onChange: (next: BrandLite[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  max?: number;
+};
+
+const DEBOUNCE = 220;
+
+const chipClass =
+  "flex items-center gap-2 rounded-full border border-neutral-700 bg-neutral-800/80 px-3 py-1 text-xs text-neutral-100";
+
+const dropdownItemClass =
+  "flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-neutral-200 hover:bg-neutral-800/60";
+
+const logoClass = "h-6 w-6 flex-shrink-0 overflow-hidden rounded-full bg-neutral-800 object-cover";
+
+const BrandSearchSelect: React.FC<Props> = ({
+  value,
+  onChange,
+  placeholder = "Search brands…",
+  disabled,
+  max,
+}) => {
+  const [query, setQuery] = React.useState("");
+  const [options, setOptions] = React.useState<BrandLite[]>([]);
+  const [open, setOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [highlight, setHighlight] = React.useState(0);
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const reachedMax = typeof max === "number" && value.length >= max;
+
+  const debouncedQuery = useDebouncedValue(query, DEBOUNCE);
+
+  React.useEffect(() => {
+    let active = true;
+
+    async function run() {
+      if (!debouncedQuery.trim()) {
+        setOptions([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      const results = await searchBrands(debouncedQuery, 8);
+      if (!active) return;
+
+      const filtered = results.filter((brand) => !value.some((v) => v.id === brand.id));
+      setOptions(filtered);
+      setLoading(false);
+      setHighlight(0);
+    }
+
+    run();
+
+    return () => {
+      active = false;
+    };
+  }, [debouncedQuery, value]);
+
+  React.useEffect(() => {
+    if (disabled) {
+      setOpen(false);
+    }
+  }, [disabled]);
+
+  React.useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    window.addEventListener("mousedown", handleClickOutside);
+    return () => window.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) {
+      setOptions([]);
+    }
+  }, [open]);
+
+  const handleSelect = React.useCallback(
+    (brand: BrandLite) => {
+      if (value.some((b) => b.id === brand.id)) return;
+      if (reachedMax) return;
+      onChange([...value, brand]);
+      setQuery("");
+      setOptions([]);
+      setOpen(false);
+      setHighlight(0);
+      inputRef.current?.focus();
+    },
+    [onChange, reachedMax, value]
+  );
+
+  const handleRemove = React.useCallback(
+    (id: number) => {
+      onChange(value.filter((brand) => brand.id !== id));
+    },
+    [onChange, value]
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setHighlight((prev) => (options.length ? (prev + 1) % options.length : 0));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlight((prev) => (options.length ? (prev - 1 + options.length) % options.length : 0));
+    } else if (event.key === "Enter") {
+      if (open && options[highlight]) {
+        event.preventDefault();
+        handleSelect(options[highlight]);
+      }
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    } else if (event.key === "Backspace" && !query) {
+      if (value.length) {
+        event.preventDefault();
+        handleRemove(value[value.length - 1].id);
+      }
+    }
+  };
+
+  const showDropdown = open && (loading || options.length > 0 || query.trim().length > 0);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div
+        className={`flex min-h-[3rem] flex-wrap items-center gap-2 rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 transition focus-within:border-pink-500 focus-within:ring-1 focus-within:ring-pink-500 ${
+          disabled ? "cursor-not-allowed opacity-60" : ""
+        }`}
+        onClick={() => {
+          if (disabled) return;
+          setOpen(true);
+          inputRef.current?.focus();
+        }}
+      >
+        {value.map((brand) => (
+          <span key={brand.id} className={chipClass}>
+            {brand.LogoBrand?.url ? (
+              <img src={brand.LogoBrand.url} alt={brand.BrandName} className={logoClass} />
+            ) : (
+              <span className={`${logoClass} flex items-center justify-center text-[10px] text-neutral-400`}>B</span>
+            )}
+            <span className="truncate max-w-[8rem]">{brand.BrandName}</span>
+            {!disabled && (
+              <button
+                type="button"
+                className="text-neutral-400 transition hover:text-pink-400"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleRemove(brand.id);
+                }}
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+
+        {!reachedMax && (
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => !disabled && setOpen(true)}
+            onKeyDown={handleKeyDown}
+            placeholder={value.length === 0 ? placeholder : ""}
+            disabled={disabled}
+            className="flex-1 min-w-[6rem] bg-transparent text-sm text-neutral-100 placeholder:text-neutral-500 focus:outline-none"
+          />
+        )}
+
+        {reachedMax && value.length > 0 && (
+          <span className="text-xs text-neutral-500">Max {max} brands</span>
+        )}
+      </div>
+
+      {showDropdown && !disabled && (
+        <div className="absolute left-0 right-0 z-20 mt-2 overflow-hidden rounded-xl border border-neutral-700/60 bg-neutral-950 shadow-xl">
+          <div className="max-h-64 overflow-y-auto">
+            {loading && (
+              <div className="px-3 py-2 text-sm text-neutral-500">Searching…</div>
+            )}
+            {!loading && options.length === 0 && (
+              <div className="px-3 py-2 text-sm text-neutral-600">No brands found.</div>
+            )}
+            {options.map((brand, index) => (
+              <button
+                key={brand.id}
+                type="button"
+                onClick={() => handleSelect(brand)}
+                className={`${dropdownItemClass} ${index === highlight ? "bg-neutral-800/80" : ""}`}
+              >
+                {brand.LogoBrand?.url ? (
+                  <img src={brand.LogoBrand.url} alt={brand.BrandName} className={logoClass} />
+                ) : (
+                  <span className={`${logoClass} flex items-center justify-center text-[10px] text-neutral-500`}>B</span>
+                )}
+                <span className="flex-1 truncate">{brand.BrandName}</span>
+              </button>
+            ))}
+          </div>
+          <div className="border-t border-neutral-800/60 px-3 py-2 text-xs text-neutral-500">
+            + Create Brand (coming soon)
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+function useDebouncedValue<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = React.useState(value);
+
+  React.useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+export default BrandSearchSelect;

--- a/src/pages/PortfolioNewPage.tsx
+++ b/src/pages/PortfolioNewPage.tsx
@@ -3,8 +3,9 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { request } from "@/services/xano";
 import WorkBodyUploader, { WBFile } from "@/components/WorkBodyUploader";
+import BrandSearchSelect from "@/components/BrandSearchSelect";
+import type { BrandLite } from "@/services/brands";
 
-type BrandLite = { id: number; BrandName: string; LogoBrand?: { url?: string } };
 type UserLite  = { id: number; handle?: string; name?: string; avatar?: { url?: string } };
 
 type FormData = {
@@ -19,7 +20,6 @@ const input = "w-full rounded-xl border px-3 py-2 text-sm bg-white dark:bg-neutr
 const label = "text-xs font-medium text-neutral-700 dark:text-neutral-200";
 
 // Endpoints di ricerca (aggiusta se hai path diversi)
-const BRAND_SEARCH_PATH = import.meta.env.VITE_XANO_BRAND_SEARCH || "/brands/search";
 const USER_SEARCH_PATH  = import.meta.env.VITE_XANO_USER_SEARCH  || "/users/search";
 
 function useDebounced<T>(value: T, delay = 300) {
@@ -70,23 +70,7 @@ const PortfolioNewPage: React.FC = () => {
   const [workFiles, setWorkFiles] = useState<WBFile[]>([]);
 
   // --- Brand search (multi) ---
-  const [brandQuery, setBrandQuery] = useState("");
-  const debBrand = useDebounced(brandQuery, 300);
-  const [brandOpts, setBrandOpts]   = useState<BrandLite[]>([]);
   const [brandsSel, setBrandsSel]   = useState<BrandLite[]>([]);
-
-  React.useEffect(() => {
-    (async () => {
-      if (!debBrand) { setBrandOpts([]); return; }
-      try {
-        const res = await request<BrandLite[] | { items: BrandLite[] }>(`${BRAND_SEARCH_PATH}?q=${encodeURIComponent(debBrand)}`);
-        const list = Array.isArray(res) ? res : (res as any)?.items || [];
-        setBrandOpts(list);
-      } catch {
-        setBrandOpts([]);
-      }
-    })();
-  }, [debBrand]);
 
   // --- Team search (multi) ---
   const [teamQuery, setTeamQuery] = useState("");
@@ -195,45 +179,8 @@ const PortfolioNewPage: React.FC = () => {
           {/* --- Brand multi-search --- */}
           <div>
             <label className={label}>Brands</label>
-            <div className="flex gap-2 flex-wrap mb-2">
-              {brandsSel.map(b => (
-                <Chip key={b.id} onRemove={() => setBrandsSel(prev => prev.filter(x => x.id !== b.id))}>
-                  {b.BrandName}
-                </Chip>
-              ))}
-            </div>
-            <input
-              value={brandQuery}
-              onChange={(e) => setBrandQuery(e.target.value)}
-              className={input}
-              placeholder="Cerca brand..."
-            />
-            {!!brandOpts.length && (
-              <div className="mt-2 rounded-xl border bg-white dark:bg-neutral-900 max-h-48 overflow-auto">
-                {brandOpts.map(o => (
-                  <button
-                    key={o.id}
-                    type="button"
-                    onClick={() => {
-                      if (!brandsSel.find(b => b.id === o.id)) setBrandsSel(prev => [...prev, o]);
-                      setBrandQuery("");
-                      setBrandOpts([]);
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
-                  >
-                    {o.BrandName}
-                  </button>
-                ))}
-              </div>
-            )}
             <div className="mt-2">
-              <button
-                type="button"
-                onClick={() => alert("Create Brand: coming soon")}
-                className="text-xs underline opacity-80"
-              >
-                + Create Brand (coming soon)
-              </button>
+              <BrandSearchSelect value={brandsSel} onChange={setBrandsSel} disabled={isSubmitting} />
             </div>
           </div>
 

--- a/src/services/brands.ts
+++ b/src/services/brands.ts
@@ -1,0 +1,104 @@
+export type BrandLite = {
+  id: number;
+  BrandName: string;
+  LogoBrand?: { url?: string } | null;
+};
+
+export function getToken(): string {
+  try {
+    if (typeof window !== "undefined") {
+      return (
+        localStorage.getItem("user_turbo_id_token") ||
+        localStorage.getItem("user_turbo_token") ||
+        localStorage.getItem("auth_token") ||
+        ""
+      );
+    }
+  } catch (error) {
+    console.warn("Unable to read auth token from storage", error);
+  }
+  return "";
+}
+
+const BRAND_ENDPOINT = "https://xbut-eryu-hhsg.f2.xano.io/api:vGd6XDW3/brand";
+
+function normalizeBrands(items: unknown[]): BrandLite[] {
+  return items
+    .map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const { id, BrandName, LogoBrand } = item as {
+        id?: unknown;
+        BrandName?: unknown;
+        LogoBrand?: unknown;
+      };
+
+      const numericId = typeof id === "number" ? id : Number(id);
+      const name = typeof BrandName === "string" ? BrandName : "";
+      let logo: BrandLite["LogoBrand"] = null;
+      if (LogoBrand && typeof LogoBrand === "object") {
+        const url = (LogoBrand as { url?: unknown }).url;
+        logo = typeof url === "string" ? { url } : null;
+      }
+
+      if (!Number.isFinite(numericId) || !name) {
+        return null;
+      }
+
+      return {
+        id: numericId,
+        BrandName: name,
+        LogoBrand: logo,
+      } satisfies BrandLite;
+    })
+    .filter((item): item is BrandLite => Boolean(item));
+}
+
+export async function searchBrands(q: string, limit = 8): Promise<BrandLite[]> {
+  const query = q.trim();
+  if (!query) {
+    return [];
+  }
+
+  const params = new URLSearchParams();
+  params.set("q", query);
+  if (limit) {
+    params.set("limit", String(limit));
+  }
+
+  const headers: HeadersInit = { Accept: "application/json" };
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(`${BRAND_ENDPOINT}?${params.toString()}`, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      console.error("Brand search failed", response.status, response.statusText);
+      return [];
+    }
+
+    const data = await response.json();
+    const list = Array.isArray(data)
+      ? data
+      : data && typeof data === "object" && "items" in data && Array.isArray((data as { items: unknown[] }).items)
+      ? (data as { items: unknown[] }).items
+      : [];
+
+    const normalized = normalizeBrands(list);
+
+    if (!query) {
+      return normalized;
+    }
+
+    const lowered = query.toLowerCase();
+    return normalized.filter((brand) => brand.BrandName.toLowerCase().includes(lowered)).slice(0, limit);
+  } catch (error) {
+    console.error("Brand search error", error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add a brand service for the Xano /brand endpoint that reuses the existing auth token handling and filters results client-side when needed
- introduce a reusable BrandSearchSelect component with debounced search, keyboard support, logo previews, and chips for multi-select
- wire the new selector into the portfolio creation page while preserving the existing form submission contract

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e60b318a40832ab9eb3ed2ee65b2c3