### PR TITLE
Add team search select with role support

### DIFF
--- a/src/components/TeamSearchSelect.tsx
+++ b/src/components/TeamSearchSelect.tsx
@@ -1,0 +1,186 @@
+import * as React from "react";
+import { searchUsers, type UserLite } from "@/services/users";
+
+export type Teammate = UserLite & { role: string };
+
+type Props = {
+  value: Teammate[];
+  onChange: (next: Teammate[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  max?: number;
+  roles?: string[];
+};
+
+const DEFAULT_ROLES = [
+  "Photographer",
+  "Videographer",
+  "Model",
+  "MUA",
+  "Stylist",
+  "Producer",
+  "Assistant",
+  "Retoucher",
+  "Director",
+  "Other",
+];
+
+export default function TeamSearchSelect({
+  value,
+  onChange,
+  placeholder = "Cerca utente...",
+  disabled,
+  max = 10,
+  roles = DEFAULT_ROLES,
+}: Props) {
+  const [q, setQ] = React.useState("");
+  const [open, setOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [results, setResults] = React.useState<UserLite[]>([]);
+  const [active, setActive] = React.useState(0);
+  const boxRef = React.useRef<HTMLDivElement | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    let alive = true;
+    const h = setTimeout(async () => {
+      try {
+        if (!q) { setResults([]); return; }
+        setLoading(true);
+        const r = await searchUsers(q);
+        if (!alive) return;
+        const selected = new Set(value.map(v => v.id));
+        setResults(r.filter(u => !selected.has(u.id)));
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 220);
+    return () => { alive = false; clearTimeout(h); };
+  }, [q, value]);
+
+  React.useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (!boxRef.current) return;
+      if (!boxRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  const add = (u: UserLite) => {
+    if (disabled) return;
+    if (value.find(v => v.id === u.id)) return;
+    if (value.length >= max) return;
+    onChange([...value, { ...u, role: roles[0] }]);
+    setQ(""); setResults([]); setActive(0);
+    inputRef.current?.focus();
+  };
+
+  const removeAt = (i: number) => {
+    const next = [...value]; next.splice(i, 1); onChange(next);
+    inputRef.current?.focus();
+  };
+
+  const setRoleAt = (i: number, role: string) => {
+    const next = [...value]; next[i] = { ...next[i], role }; onChange(next);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setActive(a => Math.min(a + 1, Math.max(results.length - 1, 0)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive(a => Math.max(a - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && results[active]) {
+        e.preventDefault();
+        add(results[active]);
+      }
+    } else if (e.key === "Backspace" && !q && value.length) {
+      removeAt(value.length - 1);
+    }
+  };
+
+  return (
+    <div ref={boxRef} className="relative">
+      <div
+        className={`min-h-11 w-full rounded-xl border border-neutral-700/60 bg-neutral-900 px-2 py-1.5 flex flex-wrap gap-2 focus-within:ring-1 focus-within:ring-pink-500 ${disabled ? "opacity-60" : ""}`}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {value.map((u, i) => (
+          <span key={u.id} className="inline-flex items-center gap-2 rounded-full bg-neutral-800 px-2 py-1">
+            {u.avatar?.url ? (
+              <img src={u.avatar.url} alt="" className="h-5 w-5 rounded-full object-cover" />
+            ) : (
+              <span className="h-5 w-5 rounded-full bg-neutral-700 grid place-items-center text-[10px]">U</span>
+            )}
+            <span className="text-sm">{u.name || u.handle || `ID ${u.id}`}</span>
+
+            <select
+              value={u.role}
+              onChange={(e) => setRoleAt(i, e.target.value)}
+              className="ml-1 rounded-md bg-neutral-900 border border-neutral-700/60 text-xs px-1 py-0.5"
+            >
+              {roles.map(r => <option key={r} value={r}>{r}</option>)}
+            </select>
+
+            <button
+              type="button"
+              className="ml-1 text-xs text-neutral-400 hover:text-white"
+              onClick={() => removeAt(i)}
+              aria-label={`Remove ${u.name || u.handle || u.id}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          ref={inputRef}
+          value={q}
+          onChange={(e) => { setQ(e.target.value); setOpen(true); }}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          disabled={disabled || value.length >= max}
+          className="flex-1 bg-transparent outline-none text-sm placeholder:text-neutral-500 min-w-[140px]"
+        />
+      </div>
+
+      {open && (q || loading) && (
+        <div className="absolute z-20 mt-1 w-full rounded-xl border border-neutral-700/60 bg-neutral-950 shadow-lg">
+          {loading && (
+            <div className="px-3 py-2 text-sm text-neutral-400">Searching…</div>
+          )}
+          {!loading && results.length === 0 && (
+            <div className="px-3 py-2 text-sm text-neutral-400">
+              Nessun utente trovato
+            </div>
+          )}
+          {!loading && results.map((u, i) => (
+            <button
+              key={u.id}
+              type="button"
+              onMouseEnter={() => setActive(i)}
+              onClick={() => add(u)}
+              className={`w-full px-3 py-2 text-left flex items-center gap-2 hover:bg-neutral-800 ${i===active ? "bg-neutral-800" : ""}`}
+            >
+              {u.avatar?.url ? (
+                <img src={u.avatar.url} className="h-7 w-7 rounded-md object-cover" />
+              ) : (
+                <div className="h-7 w-7 rounded-md bg-neutral-700 grid place-items-center text-[10px]">U</div>
+              )}
+              <div className="min-w-0">
+                <div className="truncate">{u.name || u.handle || `ID ${u.id}`}</div>
+                {u.handle && <div className="text-xs text-neutral-400 truncate">{u.handle}</div>}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PortfolioNewPage.tsx
+++ b/src/pages/PortfolioNewPage.tsx
@@ -1,12 +1,10 @@
 import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import { request } from "@/services/xano";
 import WorkBodyUploader, { WBFile } from "@/components/WorkBodyUploader";
 import BrandSearchSelect from "@/components/BrandSearchSelect";
+import TeamSearchSelect, { type Teammate } from "@/components/TeamSearchSelect";
 import type { BrandLite } from "@/services/brands";
-
-type UserLite  = { id: number; handle?: string; name?: string; avatar?: { url?: string } };
 
 type FormData = {
   Name: string;
@@ -18,27 +16,6 @@ type FormData = {
 
 const input = "w-full rounded-xl border px-3 py-2 text-sm bg-white dark:bg-neutral-900 border-neutral-300 dark:border-neutral-700 placeholder:text-neutral-400";
 const label = "text-xs font-medium text-neutral-700 dark:text-neutral-200";
-
-// Endpoints di ricerca (aggiusta se hai path diversi)
-const USER_SEARCH_PATH  = import.meta.env.VITE_XANO_USER_SEARCH  || "/users/search";
-
-function useDebounced<T>(value: T, delay = 300) {
-  const [v, setV] = useState(value);
-  React.useEffect(() => {
-    const id = setTimeout(() => setV(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return v;
-}
-
-const Chip: React.FC<React.PropsWithChildren<{ onRemove?: () => void }>> = ({ children, onRemove }) => (
-  <span className="inline-flex items-center gap-1 rounded-full bg-neutral-200 dark:bg-neutral-800 px-2 py-1 text-xs">
-    {children}
-    {onRemove && (
-      <button type="button" onClick={onRemove} className="ml-1 text-[11px] opacity-70 hover:opacity-100">✕</button>
-    )}
-  </span>
-);
 
 function parseKPI(text?: string) {
   const rows = (text || "").split("\n").map(s => s.trim()).filter(Boolean);
@@ -73,23 +50,7 @@ const PortfolioNewPage: React.FC = () => {
   const [brandsSel, setBrandsSel]   = useState<BrandLite[]>([]);
 
   // --- Team search (multi) ---
-  const [teamQuery, setTeamQuery] = useState("");
-  const debTeam = useDebounced(teamQuery, 300);
-  const [teamOpts, setTeamOpts]   = useState<UserLite[]>([]);
-  const [teamSel, setTeamSel]     = useState<UserLite[]>([]);
-
-  React.useEffect(() => {
-    (async () => {
-      if (!debTeam) { setTeamOpts([]); return; }
-      try {
-        const res = await request<UserLite[] | { items: UserLite[] }>(`${USER_SEARCH_PATH}?q=${encodeURIComponent(debTeam)}`);
-        const list = Array.isArray(res) ? res : (res as any)?.items || [];
-        setTeamOpts(list);
-      } catch {
-        setTeamOpts([]);
-      }
-    })();
-  }, [debTeam]);
+  const [teamSel, setTeamSel] = useState<Teammate[]>([]);
 
   // --- Helpers ---
   const previewCover = useMemo(() => (coverFile ? URL.createObjectURL(coverFile) : null), [coverFile]);
@@ -112,6 +73,7 @@ const PortfolioNewPage: React.FC = () => {
     }
     if (brandsSel.length) form.append("Brand", JSON.stringify(brandsSel.map(b => b.id)));
     if (teamSel.length) form.append("Team", JSON.stringify(teamSel.map(u => u.id)));
+    if (teamSel.length) form.append("TeamRoles", JSON.stringify(teamSel.map(t => ({ id: t.id, role: t.role }))));
     if (v.KPI) form.append("KPI", JSON.stringify(parseKPI(v.KPI)));
     if (v.About) form.append("About", v.About);
 
@@ -187,37 +149,10 @@ const PortfolioNewPage: React.FC = () => {
           {/* --- Team multi-search --- */}
           <div>
             <label className={label}>Team</label>
-            <div className="flex gap-2 flex-wrap mb-2">
-              {teamSel.map(u => (
-                <Chip key={u.id} onRemove={() => setTeamSel(prev => prev.filter(x => x.id !== u.id))}>
-                  {u.handle || u.name || `User #${u.id}`}
-                </Chip>
-              ))}
+            <div className="mt-2">
+              <TeamSearchSelect value={teamSel} onChange={setTeamSel} disabled={isSubmitting} />
             </div>
-            <input
-              value={teamQuery}
-              onChange={(e) => setTeamQuery(e.target.value)}
-              className={input}
-              placeholder="Cerca utente..."
-            />
-            {!!teamOpts.length && (
-              <div className="mt-2 rounded-xl border bg-white dark:bg-neutral-900 max-h-48 overflow-auto">
-                {teamOpts.map(o => (
-                  <button
-                    key={o.id}
-                    type="button"
-                    onClick={() => {
-                      if (!teamSel.find(u => u.id === o.id)) setTeamSel(prev => [...prev, o]);
-                      setTeamQuery("");
-                      setTeamOpts([]);
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
-                  >
-                    {o.handle || o.name || `User #${o.id}`}
-                  </button>
-                ))}
-              </div>
-            )}
+            <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">Seleziona utenti e imposta il ruolo.</div>
           </div>
 
           {/* --- Uploaders --- */}

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,0 +1,46 @@
+const API = "https://xbut-eryu-hhsg.f2.xano.io/api:vGd6XDW3";
+
+function getToken() {
+  return (
+    localStorage.getItem("user_turbo_id_token") ||
+    localStorage.getItem("user_turbo_token") ||
+    localStorage.getItem("auth_token") ||
+    ""
+  );
+}
+
+export type UserLite = {
+  id: number;
+  name?: string | null;
+  handle?: string | null;
+  avatar?: { url?: string } | null;
+};
+
+export async function searchUsers(q: string, limit = 8): Promise<UserLite[]> {
+  const url = new URL(API + "/user_turbo");
+  if (q) url.searchParams.set("q", q);
+  url.searchParams.set("limit", String(limit));
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${getToken()}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const data = await res.json();
+
+  const list: UserLite[] = Array.isArray(data)
+    ? data
+    : Array.isArray((data as any).items)
+    ? (data as any).items
+    : [];
+
+  if (q) {
+    const ql = q.toLowerCase();
+    return list
+      .filter(u =>
+        (u.name || "").toLowerCase().includes(ql) ||
+        (u.handle || "").toLowerCase().includes(ql)
+      )
+      .slice(0, limit);
+  }
+  return list.slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- add a users service that queries the Xano `user_turbo` endpoint with auth tokens reused from localStorage
- create a reusable `TeamSearchSelect` component that supports multi-select, role assignment, keyboard navigation, and avatar rendering
- integrate the new team selector into the portfolio creation form and submit both teammate IDs and role metadata

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e632422fc8832aafa6121e1a1f8878